### PR TITLE
assignment: two-sum

### DIFF
--- a/Array101/hyunjeong/find_numbers_with_even_number_of_digits.cc
+++ b/Array101/hyunjeong/find_numbers_with_even_number_of_digits.cc
@@ -1,0 +1,28 @@
+class Solution {
+public:
+    int findNumbers(vector<int>& nums) {
+        // 1. CS 배경지식 
+        //    - 자릿수와 관련한 연산인 나누기, 곱하기 연산이 무거운 연산이었던 걸로 기억함
+        //      => 그래서 처음에는 if문 내부에서 비교 연산자를 사용하면, 내부적으로 빼기/더하기 연산을 해서 비교하기 때문에 더 가볍다고 생각하여 아래와 같이 작성함.
+        //         하지만 결과적으로 나누기 연산으로 푸는게 속도가 더 빨랐기 때문에 다시 조사해봐야 할듯
+        //        int count = 0;
+        //        for(int i = 0; i < nums.size(); ++i) {
+        //            if ((nums[i] >= 10 && nums[i] < 100) || (nums[i] >= 1000 && nums[i] <10000) || (nums[i] == 100000)) {
+        //                count++;
+        //            }
+        //        }
+        //        return count;
+        //    - 자릿수 세는 기준이 10진수이기 때문에 2진수를 사용하는 shift 연산이나 bitwise 연산을 활용하기는 어렵지 않을까?
+        int count = 0;
+        for(int i = 0; i < nums.size(); ++i) {
+            int tmp = nums[i];
+            int digit = 0;
+            while (tmp != 0) {
+                tmp /= 10;
+                digit++;
+            }
+            if (digit % 2 == 0) count++;
+        }
+        return count;
+    }
+};

--- a/Array101/hyunjeong/max_consecutive_ones.cc
+++ b/Array101/hyunjeong/max_consecutive_ones.cc
@@ -1,0 +1,19 @@
+class Solution {
+public:
+    int findMaxConsecutiveOnes(vector<int>& nums) {
+        int count = 0;
+        int max_count = 0;
+        for (int i = 0; i < nums.size(); ++i) {
+            if (nums[i] == 1) {
+                count++;
+            } else {
+                max_count = count > max_count ? count: max_count;
+                count = 0;
+                // 남아있는 원소 개수가 현재 max_count보다 적으면 더이상 탐색x
+                if (nums.size() - i < max_count) break;
+            }
+        }
+        max_count = count > max_count ? count: max_count;
+        return max_count;
+    }
+};

--- a/Array101/hyunjeong/squares_of_a_sorted_array.cc
+++ b/Array101/hyunjeong/squares_of_a_sorted_array.cc
@@ -1,0 +1,48 @@
+class Solution {
+public:
+    vector<int> sortedSquares(vector<int>& nums) {
+        // 1. 수학적으로 제곱수의 비교는 원소의 절대값을 비교하는 것과 같음. 따라서 양수와 음수의 기준인 '0'에 가장 가까운 값을 target 배열의 시작값으로 둬야함.
+        // 2. CS 배경지식 - 투 포인터 알고리즘을 수행하기 위해 추가 배열(target_arr)을 선언함. 처음에는 공간 복잡도를 늘릴 생각을 못 해서 원본 배열 1개만으로 어떻게 정렬하지? 같은 바보같은 생각을 했음..
+        
+        // 1) for문 돌면서 제곱한 값을 원소에 넣어주고 0에 가장 가까운 값 찾기. 해당 원소의 index 저장(m)
+        // 2) 투 포인터 - pointer#1 [0, m-1] 범위 탐색(역순)/ m / pointer#2 [m+1, n] 범위 탐색
+        int min_idx = -1;
+        int min = 987654321;
+        for (int i = 0; i < nums.size(); ++i) {
+            nums[i] *= nums[i];
+            if (nums[i] < min) {
+                min = nums[i];
+                min_idx = i;
+            }
+        }
+        
+        vector<int> target_arr(nums.size());
+        target_arr[0] = nums[min_idx];
+        int target_idx = 1;
+        int pointer_1 = min_idx - 1;
+        int pointer_2 = min_idx + 1;
+        while (pointer_1 >= 0 && pointer_2 < nums.size()) {
+            // 작거나 같은 값 선택
+            int value = -1;
+            if (nums[pointer_1] <= nums[pointer_2]) {
+                value = nums[pointer_1--];
+            } else {
+                value = nums[pointer_2++];  
+            }
+            target_arr[target_idx++] = value;
+        }
+        // 남은 값들 순차적으로 target_arr에 삽입
+        if (pointer_1 < 0) {
+            while (target_idx < nums.size()) {
+                target_arr[target_idx++] = nums[pointer_2++];
+            }
+        }
+        if (pointer_2 >= nums.size()) {
+            while (target_idx < nums.size()) {
+                target_arr[target_idx++] = nums[pointer_1--];
+            }
+        }
+        
+        return target_arr;
+    }
+};

--- a/two-sum/hyunjeong/two-sum.cc
+++ b/two-sum/hyunjeong/two-sum.cc
@@ -1,0 +1,13 @@
+class Solution {
+public:
+    vector<int> twoSum(vector<int>& nums, int target) {
+        for (int i = 0; i < nums.size(); ++i) {
+            for (int j = i + 1; j < nums.size(); ++j) {
+                if (nums[i] + nums[j] == target) {
+                    return vector<int> { i, j };
+                }
+            }
+        }
+        return vector<int> { -1 };
+    }
+};


### PR DESCRIPTION
`O(n^2)` 보다 낮은 시간 복잡도로 풀려면?

1. CS 배경지식 
     - 배열은 메모리상 1차원 연속 공간에 저장됨
     - 배열 정렬 알고리즘 중에 가장 낮은 시간 복잡도를 가지는 **병합정렬**이나 **힙정렬**은 `O(nlogn)` 복잡도를 가진다.
     - 정렬된 배열에 대해서 탐색하는 알고리즘 중에 가장 낮은 시간 복잡도를 가진 **이진 탐색** 알고리즘은 `O(logn)` 복잡도를 가진다.

2. 수학적으로는 target보다 더 큰 원소들에 대해서는 탐색할 필요가 없다.

=> 위 두 가지 사실을 이용해서 1) {원소, index} 쌍을 저장하는 자료구조를 만들고, 2) 원소를 기준으로 오름차순으로 `O(nlogn)` 복잡도로 정렬한 다음, 3) 정렬된 배열에 대해서 이진 탐색으로 target보다 큰 원소는 탐색 범위에서 제외함. 

그런데 이진 탐색 알고리즘으로 two sum을 찾을수 있나?? 복잡도만 기억나서 더 이상 분석이 어렵다.